### PR TITLE
release: NosLog v1.0.1

### DIFF
--- a/app/(nevigation)/(home)/page.tsx
+++ b/app/(nevigation)/(home)/page.tsx
@@ -8,6 +8,7 @@ import {
     getCachedUserRankingPage,
     getUserRankingPosition,
 } from "@/lib/rankings";
+import type { UserRankingMode } from "@/lib/rankings";
 import { getUser } from "@/lib/user";
 import {
     formatToComma,
@@ -27,10 +28,19 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 
-export default async function Home() {
+interface HomeProps {
+    searchParams: Promise<{
+        ranking?: string | string[];
+    }>;
+}
+
+export default async function Home({ searchParams }: HomeProps) {
+    const { ranking } = await searchParams;
+    const rankingMode: UserRankingMode =
+        ranking === "recital" ? "recital" : "basic";
     const [user, { rows: rankingUsers }] = await Promise.all([
         getUser(),
-        getCachedUserRankingPage("basic", "all", 1, 5),
+        getCachedUserRankingPage(rankingMode, "all", 1, 5),
     ]);
     const userRank = user
         ? await getUserRankingPosition({
@@ -57,7 +67,7 @@ export default async function Home() {
                                 {user.username || "이름 없는 유저"}
                             </strong>
                             <span className="text-text-secondary shrink-0 text-sm">
-                                · {userRank ? `#${userRank}위` : "순위 -"}
+                                · {userRank ? `#${userRank}` : "순위 -"}
                             </span>
                         </div>
                         <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
@@ -77,7 +87,7 @@ export default async function Home() {
 
                     <Link
                         href={`/profile/${user.id}`}
-                        className="border-border text-text-primary rounded-card flex h-9 shrink-0 items-center justify-center border px-3 text-xs font-bold"
+                        className="border-border text-text-primary hover:bg-surface-muted focus-visible:ring-text-secondary/30 rounded-card flex h-9 shrink-0 cursor-pointer items-center justify-center border px-3 text-xs font-bold transition-colors focus-visible:ring-2 focus-visible:outline-none"
                     >
                         내 프로필
                     </Link>
@@ -125,10 +135,10 @@ export default async function Home() {
             <section className="grid grid-cols-3 gap-2">
                 <Link
                     href="/music"
-                    className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
+                    className="bg-surface hover:bg-surface-muted focus-visible:ring-text-secondary/30 rounded-card group flex h-20 flex-col items-center justify-center gap-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
                     <Music2
-                        className="text-text-secondary size-6"
+                        className="text-text-secondary group-hover:text-text-primary size-6 transition-colors"
                         aria-hidden="true"
                     />
                     <span className="text-caption text-text-primary font-semibold">
@@ -137,10 +147,10 @@ export default async function Home() {
                 </Link>
                 <Link
                     href="/rankings"
-                    className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
+                    className="bg-surface hover:bg-surface-muted focus-visible:ring-text-secondary/30 rounded-card group flex h-20 flex-col items-center justify-center gap-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
                     <Trophy
-                        className="text-text-secondary size-6"
+                        className="text-text-secondary group-hover:text-text-primary size-6 transition-colors"
                         aria-hidden="true"
                     />
                     <span className="text-caption text-text-primary font-semibold">
@@ -149,10 +159,10 @@ export default async function Home() {
                 </Link>
                 <Link
                     href="/bingo"
-                    className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
+                    className="bg-surface hover:bg-surface-muted focus-visible:ring-text-secondary/30 rounded-card group flex h-20 flex-col items-center justify-center gap-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
                     <Grid3X3
-                        className="text-text-secondary size-6"
+                        className="text-text-secondary group-hover:text-text-primary size-6 transition-colors"
                         aria-hidden="true"
                     />
                     <span className="text-caption text-text-primary font-semibold">
@@ -161,10 +171,10 @@ export default async function Home() {
                 </Link>
                 <Link
                     href="/tiers"
-                    className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
+                    className="bg-surface hover:bg-surface-muted focus-visible:ring-text-secondary/30 rounded-card group flex h-20 flex-col items-center justify-center gap-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
                     <ListOrdered
-                        className="text-text-secondary size-6"
+                        className="text-text-secondary group-hover:text-text-primary size-6 transition-colors"
                         aria-hidden="true"
                     />
                     <span className="text-caption text-text-primary font-semibold">
@@ -173,10 +183,10 @@ export default async function Home() {
                 </Link>
                 <Link
                     href="/exams"
-                    className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
+                    className="bg-surface hover:bg-surface-muted focus-visible:ring-text-secondary/30 rounded-card group flex h-20 flex-col items-center justify-center gap-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
                     <BadgeCheck
-                        className="text-text-secondary size-6"
+                        className="text-text-secondary group-hover:text-text-primary size-6 transition-colors"
                         aria-hidden="true"
                     />
                     <span className="text-caption text-text-primary font-semibold">
@@ -199,17 +209,17 @@ export default async function Home() {
             {/* 데이터 연동 가이드 */}
             <Link
                 href="/bookmarklet"
-                className="bg-surface rounded-card flex h-10 items-center justify-between px-4"
+                className="bg-surface hover:bg-surface-muted focus-visible:ring-text-secondary/30 rounded-card group flex h-10 items-center justify-between px-4 transition-colors focus-visible:ring-2 focus-visible:outline-none"
             >
                 <div className="flex items-center gap-2">
                     <DatabaseZap
-                        className="text-text-secondary size-4"
+                        className="text-text-secondary group-hover:text-text-primary size-4 transition-colors"
                         aria-hidden="true"
                     />
                     <span className="text-caption">데이터 연동 가이드</span>
                 </div>
                 <ChevronRight
-                    className="text-text-disabled size-4"
+                    className="text-text-disabled group-hover:text-text-primary size-4 transition-colors"
                     aria-hidden="true"
                 />
             </Link>
@@ -220,17 +230,43 @@ export default async function Home() {
                         <h2 className="text-section">유저 랭킹</h2>
 
                         <div className="border-border rounded-card flex overflow-hidden border">
-                            <span className="bg-border text-text-primary px-2 py-1 text-[10px] font-medium">
+                            <Link
+                                href="/?ranking=basic"
+                                replace
+                                scroll={false}
+                                aria-current={
+                                    rankingMode === "basic" ? "page" : undefined
+                                }
+                                className={
+                                    rankingMode === "basic"
+                                        ? "bg-border text-text-primary px-2 py-1 text-[10px] font-medium"
+                                        : "text-text-secondary hover:bg-border/60 hover:text-text-primary px-2 py-1 text-[10px] font-medium transition-colors"
+                                }
+                            >
                                 Basic
-                            </span>
-                            <span className="text-text-secondary px-2 py-1 text-[10px] font-medium">
+                            </Link>
+                            <Link
+                                href="/?ranking=recital"
+                                replace
+                                scroll={false}
+                                aria-current={
+                                    rankingMode === "recital"
+                                        ? "page"
+                                        : undefined
+                                }
+                                className={
+                                    rankingMode === "recital"
+                                        ? "bg-border text-text-primary px-2 py-1 text-[10px] font-medium"
+                                        : "text-text-secondary hover:bg-border/60 hover:text-text-primary px-2 py-1 text-[10px] font-medium transition-colors"
+                                }
+                            >
                                 Recital
-                            </span>
+                            </Link>
                         </div>
                     </div>
 
                     <Link
-                        href="/rankings"
+                        href={`/rankings?mode=${rankingMode}`}
                         className="text-caption hover:text-text-primary transition-colors"
                     >
                         전체 →

--- a/app/(nevigation)/(home)/page.tsx
+++ b/app/(nevigation)/(home)/page.tsx
@@ -1,6 +1,30 @@
-import { getCachedUserRankingPage } from "@/lib/rankings";
+import OfficialXTimeline from "@/components/home/officialXTimeline";
+import {
+    CountryMark,
+    ExamBadge,
+    UserAvatar,
+} from "@/components/rankings/table/rankingUserMeta";
+import {
+    getCachedUserRankingPage,
+    getUserRankingPosition,
+} from "@/lib/rankings";
 import { getUser } from "@/lib/user";
-import { formatToGrade } from "@/lib/utils";
+import {
+    formatToComma,
+    formatToGrade,
+    normalizeStoredGrade,
+} from "@/lib/utils";
+import {
+    BadgeCheck,
+    ChevronRight,
+    Clock3,
+    DatabaseZap,
+    Grid3X3,
+    ListOrdered,
+    Music2,
+    Search,
+    Trophy,
+} from "lucide-react";
 import Link from "next/link";
 
 export default async function Home() {
@@ -8,23 +32,67 @@ export default async function Home() {
         getUser(),
         getCachedUserRankingPage("basic", "all", 1, 5),
     ]);
+    const userRank = user
+        ? await getUserRankingPosition({
+              userId: user.id,
+              grade: user.grade_basic,
+              mode: "basic",
+          })
+        : null;
 
     return (
         <div className="flex flex-col gap-4 px-4 py-4">
             {/* 상단 로그인/프로필 카드 */}
-            <section className="bg-surface rounded-card flex items-center justify-between p-4">
-                <p className="text-section">내 NOSTALGIA 기록 모아보기</p>
-                {user ? (
-                    <span className="text-caption">{user.username}</span>
-                ) : (
+            {user ? (
+                <section className="bg-surface rounded-card flex min-h-20 items-center gap-3 p-4">
+                    <UserAvatar
+                        avatar={user.avatar}
+                        username={user.username}
+                        size={48}
+                    />
+
+                    <div className="min-w-0 flex-1">
+                        <div className="flex min-w-0 items-center gap-1.5">
+                            <strong className="text-section truncate">
+                                {user.username || "이름 없는 유저"}
+                            </strong>
+                            <span className="text-text-secondary shrink-0 text-sm">
+                                · {userRank ? `#${userRank}위` : "순위 -"}
+                            </span>
+                        </div>
+                        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                            <span className="text-text-primary shrink-0 text-sm font-medium tabular-nums">
+                                Grd{" "}
+                                {formatToComma(
+                                    normalizeStoredGrade(user.grade_basic)
+                                )}
+                            </span>
+                            <ExamBadge mode="basic" exam={user.exam_basic} />
+                            <ExamBadge
+                                mode="recital"
+                                exam={user.exam_recital}
+                            />
+                        </div>
+                    </div>
+
+                    <Link
+                        href={`/profile/${user.id}`}
+                        className="border-border text-text-primary rounded-card flex h-9 shrink-0 items-center justify-center border px-3 text-xs font-bold"
+                    >
+                        내 프로필
+                    </Link>
+                </section>
+            ) : (
+                <section className="bg-surface rounded-card flex items-center justify-between p-4">
+                    <p className="text-section">내 NOSTALGIA 기록 모아보기</p>
                     <Link
                         href="/login"
                         className="bg-discord rounded-card text-text-primary px-3 py-2 text-xs font-bold"
                     >
                         로그인
                     </Link>
-                )}
-            </section>
+                </section>
+            )}
             {/* 히어로 + 검색 */}
             <section className="flex flex-col items-center gap-8 text-center">
                 <div className="flex flex-col items-center gap-3">
@@ -40,11 +108,17 @@ export default async function Home() {
                 </div>
 
                 <form action="/music" className="w-full">
-                    <input
-                        name="q"
-                        placeholder="곡 제목 · 아티스트 검색"
-                        className="border-border bg-surface text-input placeholder:text-text-disabled h-11 w-full rounded-full border px-4"
-                    />
+                    <div className="border-border bg-surface focus-within:border-text-secondary focus-within:ring-text-secondary/20 flex h-11 w-full items-center gap-2 rounded-full border px-4 transition focus-within:ring-2">
+                        <Search
+                            className="text-text-disabled size-5 shrink-0"
+                            aria-hidden="true"
+                        />
+                        <input
+                            name="q"
+                            placeholder="곡 제목 · 아티스트 검색"
+                            className="text-input placeholder:text-text-disabled h-full min-w-0 flex-1 bg-transparent outline-none"
+                        />
+                    </div>
                 </form>
             </section>
             {/* 퀵 메뉴 */}
@@ -53,7 +127,10 @@ export default async function Home() {
                     href="/music"
                     className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
                 >
-                    <span className="border-border size-6 rounded-md border" />
+                    <Music2
+                        className="text-text-secondary size-6"
+                        aria-hidden="true"
+                    />
                     <span className="text-caption text-text-primary font-semibold">
                         악곡
                     </span>
@@ -62,7 +139,10 @@ export default async function Home() {
                     href="/rankings"
                     className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
                 >
-                    <span className="border-border size-6 rounded-md border" />
+                    <Trophy
+                        className="text-text-secondary size-6"
+                        aria-hidden="true"
+                    />
                     <span className="text-caption text-text-primary font-semibold">
                         랭킹
                     </span>
@@ -71,7 +151,10 @@ export default async function Home() {
                     href="/bingo"
                     className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
                 >
-                    <span className="border-border size-6 rounded-md border" />
+                    <Grid3X3
+                        className="text-text-secondary size-6"
+                        aria-hidden="true"
+                    />
                     <span className="text-caption text-text-primary font-semibold">
                         빙고
                     </span>
@@ -80,7 +163,10 @@ export default async function Home() {
                     href="/tiers"
                     className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
                 >
-                    <span className="border-border size-6 rounded-md border" />
+                    <ListOrdered
+                        className="text-text-secondary size-6"
+                        aria-hidden="true"
+                    />
                     <span className="text-caption text-text-primary font-semibold">
                         서열표
                     </span>
@@ -89,13 +175,19 @@ export default async function Home() {
                     href="/exams"
                     className="bg-surface rounded-card flex h-20 flex-col items-center justify-center gap-2"
                 >
-                    <span className="border-border size-6 rounded-md border" />
+                    <BadgeCheck
+                        className="text-text-secondary size-6"
+                        aria-hidden="true"
+                    />
                     <span className="text-caption text-text-primary font-semibold">
                         검정
                     </span>
                 </Link>
                 <div className="bg-surface-muted rounded-card relative flex h-20 flex-col items-center justify-center gap-2 opacity-50">
-                    <span className="border-border size-6 rounded-md border" />
+                    <Clock3
+                        className="text-text-secondary size-6"
+                        aria-hidden="true"
+                    />
                     <span className="text-caption text-text-secondary font-semibold">
                         준비중
                     </span>
@@ -110,10 +202,16 @@ export default async function Home() {
                 className="bg-surface rounded-card flex h-10 items-center justify-between px-4"
             >
                 <div className="flex items-center gap-2">
-                    <span className="border-border size-4 rounded border" />
+                    <DatabaseZap
+                        className="text-text-secondary size-4"
+                        aria-hidden="true"
+                    />
                     <span className="text-caption">데이터 연동 가이드</span>
                 </div>
-                <span className="text-text-disabled text-base">›</span>
+                <ChevronRight
+                    className="text-text-disabled size-4"
+                    aria-hidden="true"
+                />
             </Link>
             {/* 랭킹 카드 */}
             <section className="bg-surface rounded-card overflow-hidden">
@@ -160,9 +258,17 @@ export default async function Home() {
                                 {index + 1}
                             </span>
 
-                            <span className="bg-surface-muted mr-3 h-2.5 w-4 shrink-0" />
+                            <UserAvatar
+                                avatar={rankingUser.avatar}
+                                username={rankingUser.username}
+                                size={24}
+                            />
 
-                            <span className="text-body flex-1 truncate">
+                            <span className="mx-2 flex w-4 shrink-0 items-center justify-center">
+                                <CountryMark country={rankingUser.country} />
+                            </span>
+
+                            <span className="text-body min-w-0 flex-1 truncate">
                                 {rankingUser.username ?? "Unknown"}
                             </span>
 
@@ -173,6 +279,8 @@ export default async function Home() {
                     ))}
                 </div>
             </section>
+            {/* NOSTALGIA 공식 소식 */}
+            <OfficialXTimeline />
         </div>
     );
 }

--- a/app/(nevigation)/music/[index]/[difficulty]/data.ts
+++ b/app/(nevigation)/music/[index]/[difficulty]/data.ts
@@ -1,5 +1,6 @@
 import db from "@/lib/db";
 import { CACHE_TAGS } from "@/lib/cacheTags";
+import { selectScoreImprovements } from "@/lib/music/scoreTrend";
 import { unstable_cache } from "next/cache";
 
 // 모든 탭에서 공통으로 사용하는 악곡과 채보 정보만 캐시함
@@ -255,4 +256,40 @@ export async function getRecentUserChartPlays(userId: number, chartId: number) {
         rank: play.rank,
         play_time: play.source_play_time,
     }));
+}
+
+export async function getUserChartScoreTrend(
+    userId: number,
+    chartId: number,
+    currentRecord: { score: number; rank: string; besttime: string } | null
+) {
+    const snapshots = await db.chartRecordSnapshot.findMany({
+        where: { user_id: userId, chart_id: chartId, score: { gt: 0 } },
+        select: {
+            id: true,
+            score: true,
+            rank: true,
+            created_at: true,
+        },
+        orderBy: [{ created_at: "asc" }, { id: "asc" }],
+    });
+
+    const records = snapshots.map((snapshot) => ({
+        id: snapshot.id,
+        score: snapshot.score,
+        rank: snapshot.rank,
+        play_time: snapshot.created_at.toISOString(),
+    }));
+
+    // 스냅샷 도입 전에 존재한 현재 베스트 기록도 최초 지점으로 표시함
+    if (currentRecord?.score) {
+        records.push({
+            id: -1,
+            score: currentRecord.score,
+            rank: currentRecord.rank,
+            play_time: currentRecord.besttime,
+        });
+    }
+
+    return selectScoreImprovements(records);
 }

--- a/app/(nevigation)/music/[index]/[difficulty]/page.tsx
+++ b/app/(nevigation)/music/[index]/[difficulty]/page.tsx
@@ -12,6 +12,7 @@ import {
     getCachedMusicDetail,
     getRecentUserChartPlays,
     getUserChartRecord,
+    getUserChartScoreTrend,
 } from "./data";
 
 const difficulties = ["Normal", "Hard", "Expert", "Real"] as const;
@@ -84,10 +85,13 @@ export default async function MusicDetailPage(props: {
     const userPlayData = session.id
         ? await getUserChartRecord(session.id, chart.id)
         : null;
-    const recentChartPlays =
+    const [recentChartPlays, scoreTrend] =
         session.id && activeTab === "record"
-            ? await getRecentUserChartPlays(session.id, chart.id)
-            : [];
+            ? await Promise.all([
+                  getRecentUserChartPlays(session.id, chart.id),
+                  getUserChartScoreTrend(session.id, chart.id, userPlayData),
+              ])
+            : [[], []];
 
     let evaluationCount = 0;
     let patternAverages = {
@@ -288,6 +292,7 @@ export default async function MusicDetailPage(props: {
             isLoggedIn={Boolean(session.id)}
             userPlayData={userPlayData}
             recentChartPlays={recentChartPlays}
+            scoreTrend={scoreTrend}
             chartDetail={{
                 ...chart,
                 evaluationCount,

--- a/app/(nevigation)/music/page.tsx
+++ b/app/(nevigation)/music/page.tsx
@@ -13,7 +13,7 @@ export default async function Music(props: {
     return (
         <div className="mx-auto flex h-full min-h-screen max-w-(--breakpoint-sm) flex-col gap-4 px-4 py-4">
             <header className="flex items-center justify-between">
-                <h1 className="text-title">악곡</h1>
+                <h1 className="text-title">악곡 검색</h1>
             </header>
             <MusicSearch searchParams={searchParams} />
             <MusicResults

--- a/app/(nevigation)/rankings/page.tsx
+++ b/app/(nevigation)/rankings/page.tsx
@@ -140,10 +140,10 @@ export default async function Rankings({ searchParams }: RankingsPageProps) {
                         href={filterHref(item.value, region)}
                         aria-current={item.value === mode ? "page" : undefined}
                         className={cn(
-                            "flex h-10 items-center justify-center rounded-md text-sm font-semibold",
+                            "focus-visible:ring-text-secondary/30 flex h-10 cursor-pointer items-center justify-center rounded-md text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none",
                             item.value === mode
-                                ? "bg-border text-text-primary"
-                                : "text-text-secondary"
+                                ? "bg-border text-text-primary hover:bg-border/80"
+                                : "text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                         )}
                     >
                         {item.label}
@@ -163,10 +163,10 @@ export default async function Rankings({ searchParams }: RankingsPageProps) {
                             item.value === region ? "page" : undefined
                         }
                         className={cn(
-                            "border-divider flex h-9 items-center justify-center gap-1.5 border-l text-xs font-semibold first:border-l-0",
+                            "border-divider focus-visible:ring-text-secondary/30 flex h-9 cursor-pointer items-center justify-center gap-1.5 border-l text-xs font-semibold transition-colors first:border-l-0 focus-visible:ring-2 focus-visible:outline-none",
                             item.value === region
-                                ? "bg-surface-muted text-text-primary"
-                                : "text-text-secondary"
+                                ? "bg-surface-muted text-text-primary hover:bg-border"
+                                : "text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                         )}
                     >
                         <RegionIcon icon={item.icon} />

--- a/app/(nevigation)/tiers/page.tsx
+++ b/app/(nevigation)/tiers/page.tsx
@@ -65,10 +65,10 @@ export default async function TiersPage({ searchParams }: TiersPageProps) {
                         }
                         aria-current={item.value === mode ? "page" : undefined}
                         className={cn(
-                            "flex h-9 items-center justify-center rounded-md px-4 text-sm font-semibold",
+                            "focus-visible:ring-text-secondary/30 flex h-9 cursor-pointer items-center justify-center rounded-md px-4 text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none",
                             item.value === mode
-                                ? "bg-text-primary text-bg"
-                                : "bg-surface text-text-secondary"
+                                ? "bg-text-primary text-bg hover:bg-text-primary/90"
+                                : "bg-surface text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                         )}
                     >
                         {item.label}

--- a/app/admin/community/page.tsx
+++ b/app/admin/community/page.tsx
@@ -62,10 +62,10 @@ export default async function AdminCommunityPage() {
                             </p>
                             <p className="text-caption">
                                 추천 {up} · 비추천 {down} · 계단{" "}
-                                {evaluation.stairs} / 동치 {evaluation.chord} /
-                                트릴 {evaluation.trill} / 글리산도{" "}
-                                {evaluation.glissando} / 연타{" "}
-                                {evaluation.repetition}
+                                {evaluation.stairs} / 연타{" "}
+                                {evaluation.repetition} / 폴리리듬{" "}
+                                {evaluation.chord} / 즈레 {evaluation.trill} /
+                                글리산도 {evaluation.glissando}
                             </p>
                             <form action={deleteEvaluation}>
                                 <input

--- a/app/admin/submissions/actions.ts
+++ b/app/admin/submissions/actions.ts
@@ -75,7 +75,12 @@ export async function deleteExamSubmission(formData: FormData) {
     });
     if (!submission) return;
 
-    await db.examSubmission.delete({ where: { id: submission.id } });
+    await db.$transaction(async (tx) => {
+        await tx.examAchievement.deleteMany({
+            where: { submissionId: submission.id },
+        });
+        await tx.examSubmission.delete({ where: { id: submission.id } });
+    });
     await deleteBlobIfOwned(submission.proofImageUrl);
 
     revalidatePath("/admin");

--- a/app/admin/submissions/page.tsx
+++ b/app/admin/submissions/page.tsx
@@ -150,8 +150,10 @@ export default async function AdminSubmissionsPage({
                                         value={submission.id}
                                     />
                                     <button className="border-danger/40 text-danger flex h-10 w-full cursor-pointer items-center justify-center gap-1 rounded-md border text-sm font-bold">
-                                        <Trash2 className="size-4" /> 제출 기록
-                                        삭제
+                                        <Trash2 className="size-4" />
+                                        {submission.status === "approved"
+                                            ? "합격 이력 및 제출 삭제"
+                                            : "제출 기록 삭제"}
                                     </button>
                                 </form>
                             </div>

--- a/components/bingo/bingoList.tsx
+++ b/components/bingo/bingoList.tsx
@@ -34,9 +34,7 @@ export default function BingoList({ bingos }: { bingos: BingoListItem[] }) {
         <div className="flex flex-col gap-4 px-4 py-4">
             <div className="flex items-end justify-between">
                 <h1 className="text-title">빙고</h1>
-                <p className="text-caption">
-                    {bingos.length}판 · 해금 완료 {counts.completed}
-                </p>
+                <p className="text-caption">해금 완료 {counts.completed}</p>
             </div>
 
             {continueBingo ? <ContinueBingoCard bingo={continueBingo} /> : null}

--- a/components/bingo/list/bingoListFilters.tsx
+++ b/components/bingo/list/bingoListFilters.tsx
@@ -37,10 +37,10 @@ export default function BingoListFilters({
                             type="button"
                             onClick={() => onFilterChange(item.value)}
                             className={cn(
-                                "h-8 shrink-0 rounded-md px-3 text-xs font-semibold transition-colors",
+                                "focus-visible:ring-text-secondary/30 h-8 shrink-0 cursor-pointer rounded-md px-3 text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none",
                                 filter === item.value
-                                    ? "bg-text-primary text-bg"
-                                    : "bg-surface text-text-secondary"
+                                    ? "bg-text-primary text-bg hover:bg-text-primary/90"
+                                    : "bg-surface text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                             )}
                         >
                             {item.label}
@@ -52,7 +52,7 @@ export default function BingoListFilters({
             <button
                 type="button"
                 onClick={onSortDirectionChange}
-                className="text-caption hover:text-text-primary flex h-8 shrink-0 items-center gap-1 px-1 transition-colors"
+                className="text-caption hover:bg-surface-muted hover:text-text-primary focus-visible:ring-text-secondary/30 flex h-8 shrink-0 cursor-pointer items-center gap-1 rounded px-1.5 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 aria-label={`진행률 ${sortDirection === "desc" ? "낮은 순" : "높은 순"}으로 변경`}
                 title={
                     sortDirection === "desc"

--- a/components/bingo/plate/bingoBoard.tsx
+++ b/components/bingo/plate/bingoBoard.tsx
@@ -39,7 +39,7 @@ export default function BingoBoard({
                         type="button"
                         onClick={() => onSelect(cell)}
                         className={cn(
-                            "bg-surface hover:bg-surface-muted relative flex aspect-square min-w-0 items-center justify-center rounded-md p-1.5 text-center transition-colors",
+                            "bg-surface hover:bg-surface-muted focus-visible:ring-text-secondary/30 relative flex aspect-square min-w-0 cursor-pointer items-center justify-center rounded-md p-1.5 text-center transition-colors focus-visible:ring-2 focus-visible:outline-none",
                             isCompleted && "text-chart",
                             isCompletedLine && "text-score",
                             isRich &&

--- a/components/bingo/plate/bingoMissionFilters.tsx
+++ b/components/bingo/plate/bingoMissionFilters.tsx
@@ -24,10 +24,10 @@ export default function BingoMissionFilters({
                 type="button"
                 onClick={() => onChange("incomplete")}
                 className={cn(
-                    "h-8 rounded-md px-3 text-xs font-semibold",
+                    "focus-visible:ring-text-secondary/30 h-8 cursor-pointer rounded-md px-3 text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none",
                     filter === "incomplete"
-                        ? "bg-text-primary text-bg"
-                        : "bg-surface text-text-secondary"
+                        ? "bg-text-primary text-bg hover:bg-text-primary/90"
+                        : "bg-surface text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                 )}
             >
                 미완료 {incompleteCount}
@@ -36,10 +36,10 @@ export default function BingoMissionFilters({
                 type="button"
                 onClick={() => onChange("completed")}
                 className={cn(
-                    "h-8 rounded-md px-3 text-xs font-semibold",
+                    "focus-visible:ring-text-secondary/30 h-8 cursor-pointer rounded-md px-3 text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none",
                     filter === "completed"
-                        ? "bg-text-primary text-bg"
-                        : "bg-surface text-text-secondary"
+                        ? "bg-text-primary text-bg hover:bg-text-primary/90"
+                        : "bg-surface text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                 )}
             >
                 완료 {completedCount}
@@ -48,10 +48,10 @@ export default function BingoMissionFilters({
                 type="button"
                 onClick={() => onChange("rich")}
                 className={cn(
-                    "h-8 rounded-md px-3 text-xs font-semibold",
+                    "focus-visible:ring-score/30 h-8 cursor-pointer rounded-md px-3 text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none",
                     filter === "rich"
-                        ? "bg-score text-bg"
-                        : "bg-surface text-score"
+                        ? "bg-score text-bg hover:bg-score/90"
+                        : "bg-surface text-score hover:bg-surface-muted"
                 )}
             >
                 리치만 {richCount}

--- a/components/exams/dashboard/examModeTabs.tsx
+++ b/components/exams/dashboard/examModeTabs.tsx
@@ -23,8 +23,9 @@ export default function ExamModeTabs({ mode, onChange }: ExamModeTabsProps) {
                     type="button"
                     onClick={() => onChange(item.value)}
                     className={cn(
-                        "bg-surface text-text-secondary h-8 rounded-lg px-3.5 text-xs font-semibold",
-                        mode === item.value && "bg-text-primary text-bg"
+                        "bg-surface text-text-secondary hover:bg-surface-muted hover:text-text-primary focus-visible:ring-text-secondary/30 h-8 cursor-pointer rounded-lg px-3.5 text-xs font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none",
+                        mode === item.value &&
+                            "bg-text-primary text-bg hover:bg-text-primary/90 hover:text-bg"
                     )}
                 >
                     {item.label}

--- a/components/exams/dashboard/examOverview.tsx
+++ b/components/exams/dashboard/examOverview.tsx
@@ -30,7 +30,7 @@ export default function ExamOverview({ exam }: { exam: ExamDashboardItem }) {
                             )}
                         >
                             {exam.playerGrade >= exam.requiredGrade ? "✓" : "✕"}{" "}
-                            {formatToComma(exam.playerGrade)}
+                            현재 {formatToComma(exam.playerGrade)} Grd.
                         </span>
                     ) : null}
                 </p>
@@ -55,7 +55,7 @@ export default function ExamOverview({ exam }: { exam: ExamDashboardItem }) {
                                 {reward.musicIndex ? (
                                     <Link
                                         href={`/music?q=${encodeURIComponent(reward.label)}`}
-                                        className="decoration-divider underline underline-offset-2"
+                                        className="decoration-divider hover:text-chart focus-visible:ring-text-secondary/30 rounded underline underline-offset-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                                     >
                                         {reward.label}
                                     </Link>

--- a/components/exams/dashboard/examProofUpload.tsx
+++ b/components/exams/dashboard/examProofUpload.tsx
@@ -56,12 +56,14 @@ export default function ExamProofUpload({
                 aria-disabled={disabled}
                 className={cn(
                     "border-text-disabled flex h-10 items-center justify-center gap-2 rounded-lg border border-dashed text-xs font-semibold",
-                    disabled
-                        ? "cursor-not-allowed opacity-50"
-                        : "hover:bg-surface cursor-pointer"
+                    exam.isAchieved
+                        ? "border-success/40 text-success"
+                        : disabled
+                          ? "cursor-not-allowed opacity-50"
+                          : "hover:bg-surface cursor-pointer"
                 )}
             >
-                <Upload className="size-4" />
+                {exam.isAchieved ? null : <Upload className="size-4" />}
                 {isUploading
                     ? "업로드 중..."
                     : exam.isAchieved

--- a/components/exams/dashboard/examSelector.tsx
+++ b/components/exams/dashboard/examSelector.tsx
@@ -35,7 +35,7 @@ export default function ExamSelector({
                             aria-expanded={selected}
                             onClick={() => onChange(exam.id)}
                             className={cn(
-                                "bg-surface rounded-card flex h-14 w-full items-center gap-3 px-3 text-left",
+                                "bg-surface hover:bg-surface-muted focus-visible:ring-text-secondary/30 rounded-card flex h-14 w-full cursor-pointer items-center gap-3 px-3 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none",
                                 selected && "ring-border ring-1",
                                 !selected && locked && "opacity-50"
                             )}

--- a/components/exams/dashboard/examStageTable.tsx
+++ b/components/exams/dashboard/examStageTable.tsx
@@ -63,7 +63,7 @@ function StageRow({
             </span>
             <span
                 className={cn(
-                    "text-right text-xs tabular-nums",
+                    "flex items-center justify-end gap-1.5 text-right text-xs tabular-nums",
                     stage.bestValue === null || stage.bestValue === 0
                         ? "text-text-disabled"
                         : stage.isPassed
@@ -71,11 +71,18 @@ function StageRow({
                           : "text-danger"
                 )}
             >
-                {stage.bestValue === null
-                    ? "연동 미지원"
-                    : stage.bestValue > 0
-                      ? `${formatExamValue(stage.bestValue, scoringType)} ${stage.isPassed ? "✓" : "✕"}`
-                      : "기록 없음"}
+                {stage.bestValue === null ? (
+                    "연동 미지원"
+                ) : stage.bestValue > 0 ? (
+                    <>
+                        <span>{stage.isPassed ? "✓" : "✕"}</span>
+                        <span>
+                            {formatExamValue(stage.bestValue, scoringType)}
+                        </span>
+                    </>
+                ) : (
+                    "기록 없음"
+                )}
             </span>
         </>
     );
@@ -83,7 +90,7 @@ function StageRow({
     return firstChart ? (
         <Link
             href={`/music/${stage.musicIndex}/${firstChart.difficulty.toLowerCase()}`}
-            className={rowClass}
+            className={`${rowClass} hover:bg-surface-muted focus-visible:ring-text-secondary/30 transition-colors focus-visible:ring-2 focus-visible:outline-none`}
         >
             {content}
         </Link>

--- a/components/exams/examDashboard.tsx
+++ b/components/exams/examDashboard.tsx
@@ -9,9 +9,7 @@ import {
     requestExamProofUpload,
     submitExamProof,
 } from "@/app/(nevigation)/exams/actions";
-import ExamModeTabs, {
-    EXAM_MODES,
-} from "@/components/exams/dashboard/examModeTabs";
+import ExamModeTabs from "@/components/exams/dashboard/examModeTabs";
 import ExamOverview from "@/components/exams/dashboard/examOverview";
 import ExamProofUpload from "@/components/exams/dashboard/examProofUpload";
 import ExamSelector from "@/components/exams/dashboard/examSelector";
@@ -38,10 +36,7 @@ export default function ExamDashboard({
     isAuthenticated: boolean;
 }) {
     const router = useRouter();
-    const initialMode =
-        EXAM_MODES.find((item) =>
-            exams.some((exam) => exam.mode === item.value)
-        )?.value ?? "basic";
+    const initialMode: ExamMode = "basic";
     const initialModeExams = exams.filter((exam) => exam.mode === initialMode);
     const [mode, setMode] = useState<ExamMode>(initialMode);
     const [selectedExamId, setSelectedExamId] = useState<number | null>(

--- a/components/home/officialXTimeline.tsx
+++ b/components/home/officialXTimeline.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Script from "next/script";
+import { useCallback, useEffect, useRef } from "react";
+
+const OFFICIAL_X_URL = "https://x.com/NOSTALGIA_573";
+
+type XWidgetsWindow = Window & {
+    twttr?: {
+        widgets?: {
+            load: (element?: HTMLElement) => Promise<unknown>;
+        };
+    };
+};
+
+// NOSTALGIA 공식 계정의 최신 게시물을 X 공식 위젯으로 표시함
+export default function OfficialXTimeline() {
+    const timelineRef = useRef<HTMLDivElement>(null);
+
+    const loadTimeline = useCallback(() => {
+        const container = timelineRef.current;
+        if (!container) return;
+
+        void (window as XWidgetsWindow).twttr?.widgets?.load(container);
+    }, []);
+
+    useEffect(() => {
+        loadTimeline();
+    }, [loadTimeline]);
+
+    return (
+        <section className="bg-surface rounded-card overflow-hidden">
+            <div className="bg-surface-muted flex h-10 items-center justify-between px-3">
+                <h2 className="text-section">NOSTALGIA 공식 소식</h2>
+                <a
+                    href={OFFICIAL_X_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-caption hover:text-text-primary transition-colors"
+                >
+                    공식 X →
+                </a>
+            </div>
+
+            <div ref={timelineRef} className="min-h-52 overflow-hidden">
+                <a
+                    className="twitter-timeline text-caption flex min-h-52 items-center justify-center px-4 text-center"
+                    data-theme="dark"
+                    data-lang="ko"
+                    data-tweet-limit="2"
+                    data-chrome="noheader nofooter noborders transparent"
+                    data-dnt="true"
+                    href={OFFICIAL_X_URL}
+                >
+                    NOSTALGIA 공식 X에서 최신 소식 보기
+                </a>
+            </div>
+
+            <Script
+                id="x-widgets"
+                src="https://platform.twitter.com/widgets.js"
+                strategy="lazyOnload"
+                onLoad={loadTimeline}
+                onReady={loadTimeline}
+            />
+        </section>
+    );
+}

--- a/components/music/musicDetail.tsx
+++ b/components/music/musicDetail.tsx
@@ -15,6 +15,7 @@ export default function MusicDetail({
     isLoggedIn,
     userPlayData,
     recentChartPlays,
+    scoreTrend,
     chartDetail,
     ranking,
     tier,
@@ -38,6 +39,7 @@ export default function MusicDetail({
                     isLoggedIn={isLoggedIn}
                     userPlayData={userPlayData}
                     recentChartPlays={recentChartPlays}
+                    scoreTrend={scoreTrend}
                 />
             ) : null}
 

--- a/components/music/musicDetailHeader.tsx
+++ b/components/music/musicDetailHeader.tsx
@@ -1,4 +1,8 @@
 import { cn } from "@/lib/utils";
+import {
+    MUSIC_CATEGORY_BADGE_STYLES,
+    normalizeMusicCategory,
+} from "@/lib/musicCategories";
 import { difficultyStyles } from "./musicDetailConfig";
 import type { Difficulty, MusicInfo } from "./musicDetailTypes";
 
@@ -16,6 +20,7 @@ export default function MusicDetailHeader({
     const jacketImageUrl =
         music.background ||
         `https://p.eagate.573.jp/game/nostalgia/op3/img/jacket.html?c=${music.index}`;
+    const category = normalizeMusicCategory(music.category_short);
 
     return (
         <section className="flex min-w-0 items-center gap-3">
@@ -26,7 +31,14 @@ export default function MusicDetailHeader({
             />
 
             <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                <span className="bg-surface-muted text-text-secondary w-fit rounded px-2 py-1 text-xs font-bold">
+                <span
+                    className={cn(
+                        "w-fit rounded px-2 py-1 text-xs font-bold",
+                        category
+                            ? MUSIC_CATEGORY_BADGE_STYLES[category]
+                            : "bg-surface-muted text-text-secondary"
+                    )}
+                >
                     {music.category_short}
                 </span>
                 <h1 className="text-text-primary truncate text-xl font-extrabold">

--- a/components/music/musicDetailTypes.ts
+++ b/components/music/musicDetailTypes.ts
@@ -43,6 +43,13 @@ export interface RecentChartPlay {
     play_time: string;
 }
 
+export interface ScoreTrendPoint {
+    id: number;
+    score: number;
+    rank: string;
+    play_time: string;
+}
+
 export interface ChartDetail {
     id: number;
     level: number;
@@ -79,6 +86,7 @@ export interface MusicDetailProps {
     isLoggedIn: boolean;
     userPlayData: UserPlayData | null;
     recentChartPlays: RecentChartPlay[];
+    scoreTrend: ScoreTrendPoint[];
     chartDetail: ChartDetail;
     ranking: {
         rows: RankingRow[];

--- a/components/music/musicInfoTab.tsx
+++ b/components/music/musicInfoTab.tsx
@@ -81,22 +81,22 @@ export default function MusicInfoTab({
                         <dl className="flex w-1/2 flex-col gap-2">
                             {[
                                 ["계단", chartDetail.patternAverages.stairs],
-                                ["동치", chartDetail.patternAverages.chord],
-                                ["트릴", chartDetail.patternAverages.trill],
-                                [
-                                    "글리산도",
-                                    chartDetail.patternAverages.glissando,
-                                ],
                                 [
                                     "연타",
                                     chartDetail.patternAverages.repetition,
+                                ],
+                                ["폴리리듬", chartDetail.patternAverages.chord],
+                                ["즈레", chartDetail.patternAverages.trill],
+                                [
+                                    "글리산도",
+                                    chartDetail.patternAverages.glissando,
                                 ],
                             ].map(([label, value]) => (
                                 <div
                                     key={label}
                                     className="flex items-center gap-2 text-xs"
                                 >
-                                    <dt className="text-text-secondary w-12 shrink-0">
+                                    <dt className="text-text-secondary w-14 shrink-0">
                                         {label}
                                     </dt>
                                     <div className="bg-surface-muted h-1.5 min-w-0 flex-1 overflow-hidden rounded-full">

--- a/components/music/musicRecordTab.tsx
+++ b/components/music/musicRecordTab.tsx
@@ -1,20 +1,27 @@
 import { cn, formatToComma, formatToGrade } from "@/lib/utils";
+import { formatScoreRecordDate } from "@/lib/music/scoreTrend";
 import Image from "next/image";
 import Link from "next/link";
 import { rankAssetNames } from "./musicDetailConfig";
-import type { RecentChartPlay, UserPlayData } from "./musicDetailTypes";
+import type {
+    RecentChartPlay,
+    ScoreTrendPoint,
+    UserPlayData,
+} from "./musicDetailTypes";
 import ScoreTrend from "./scoreTrend";
 
 interface MusicRecordTabProps {
     isLoggedIn: boolean;
     userPlayData: UserPlayData | null;
     recentChartPlays: RecentChartPlay[];
+    scoreTrend: ScoreTrendPoint[];
 }
 
 export default function MusicRecordTab({
     isLoggedIn,
     userPlayData,
     recentChartPlays,
+    scoreTrend,
 }: MusicRecordTabProps) {
     const scoreProgress = userPlayData
         ? Math.min(
@@ -106,15 +113,25 @@ export default function MusicRecordTab({
                         <div className="mt-1.5 flex items-center justify-between gap-3 text-[10px]">
                             <span className="text-text-disabled truncate tabular-nums">
                                 {userPlayData
-                                    ? `S 950k · ${userPlayData.besttime.split(" ")[0].replaceAll("-", ".").replaceAll("/", ".")} 달성`
+                                    ? formatScoreRecordDate(
+                                          userPlayData.besttime
+                                      )
                                     : "기록 없음"}
                             </span>
-                            <span className="text-score shrink-0 tabular-nums">
-                                {scoreToPerfect === null
-                                    ? "P(1000k)까지 -"
-                                    : scoreToPerfect === 0
-                                      ? "Perfect 달성"
-                                      : `P(1000k)까지 -${formatToComma(scoreToPerfect)}`}
+                            <span className="text-text-secondary shrink-0 tabular-nums">
+                                Pianist까지{" "}
+                                <strong
+                                    className={cn(
+                                        scoreToPerfect !== null &&
+                                            "text-success"
+                                    )}
+                                >
+                                    {scoreToPerfect === null
+                                        ? "-"
+                                        : scoreToPerfect === 0
+                                          ? "달성"
+                                          : `${formatToComma(scoreToPerfect)}점`}
+                                </strong>
                             </span>
                         </div>
                     </div>
@@ -151,11 +168,10 @@ export default function MusicRecordTab({
                 </dl>
 
                 <section className="bg-surface rounded-card p-4">
-                    <header className="flex items-center justify-between">
+                    <header>
                         <h2 className="text-sm font-bold">스코어 추이</h2>
-                        <span className="text-caption">최근 4회 갱신</span>
                     </header>
-                    <ScoreTrend plays={recentChartPlays} />
+                    <ScoreTrend points={scoreTrend} />
                 </section>
 
                 <section className="bg-surface rounded-card overflow-hidden">

--- a/components/music/musicTierVoteConfig.ts
+++ b/components/music/musicTierVoteConfig.ts
@@ -1,9 +1,9 @@
 export const patternItems = [
     { key: "stairs", label: "계단" },
-    { key: "chord", label: "동치" },
-    { key: "trill", label: "트릴" },
-    { key: "glissando", label: "글리산도" },
     { key: "repetition", label: "연타" },
+    { key: "chord", label: "폴리리듬" },
+    { key: "trill", label: "즈레" },
+    { key: "glissando", label: "글리산도" },
 ] as const;
 
 export const patternLevels = ["없음", "낮음", "보통", "높음", "매우높음"];

--- a/components/music/musicToolbar.tsx
+++ b/components/music/musicToolbar.tsx
@@ -32,10 +32,10 @@ export default function MusicToolbar({
                     type="button"
                     onClick={() => onSortModeChange("name")}
                     className={cn(
-                        "flex items-center gap-1 px-3 text-xs leading-none transition-colors",
+                        "focus-visible:ring-text-secondary/30 flex cursor-pointer items-center gap-1 px-3 text-xs leading-none transition-colors focus-visible:ring-2 focus-visible:outline-none",
                         sortMode === "name"
-                            ? "bg-border text-text-primary"
-                            : "text-text-secondary"
+                            ? "bg-border text-text-primary hover:bg-border/80"
+                            : "text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                     )}
                 >
                     <span>이름순</span>
@@ -45,10 +45,10 @@ export default function MusicToolbar({
                     type="button"
                     onClick={() => onSortModeChange("level")}
                     className={cn(
-                        "flex items-center gap-1 px-3 text-xs leading-none transition-colors",
+                        "focus-visible:ring-text-secondary/30 flex cursor-pointer items-center gap-1 px-3 text-xs leading-none transition-colors focus-visible:ring-2 focus-visible:outline-none",
                         sortMode === "level"
-                            ? "bg-border text-text-primary"
-                            : "text-text-secondary"
+                            ? "bg-border text-text-primary hover:bg-border/80"
+                            : "text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                     )}
                 >
                     <span>레벨순</span>
@@ -63,10 +63,10 @@ export default function MusicToolbar({
                     aria-pressed={viewMode === "list"}
                     onClick={() => onViewModeChange("list")}
                     className={cn(
-                        "flex w-7 items-center justify-center transition-colors",
+                        "focus-visible:ring-text-secondary/30 flex w-7 cursor-pointer items-center justify-center transition-colors focus-visible:ring-2 focus-visible:outline-none",
                         viewMode === "list"
-                            ? "bg-border text-text-primary"
-                            : "text-text-secondary"
+                            ? "bg-border text-text-primary hover:bg-border/80"
+                            : "text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                     )}
                 >
                     <List size={14} />
@@ -77,10 +77,10 @@ export default function MusicToolbar({
                     aria-pressed={viewMode === "grid"}
                     onClick={() => onViewModeChange("grid")}
                     className={cn(
-                        "flex w-7 items-center justify-center transition-colors",
+                        "focus-visible:ring-text-secondary/30 flex w-7 cursor-pointer items-center justify-center transition-colors focus-visible:ring-2 focus-visible:outline-none",
                         viewMode === "grid"
-                            ? "bg-border text-text-primary"
-                            : "text-text-secondary"
+                            ? "bg-border text-text-primary hover:bg-border/80"
+                            : "text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                     )}
                 >
                     <Grid2X2 size={14} />

--- a/components/music/patternProfileChart.tsx
+++ b/components/music/patternProfileChart.tsx
@@ -24,10 +24,10 @@ export default function PatternProfileChart({
 }: PatternProfileChartProps) {
     const data = [
         { label: "계단", value: values.stairs },
-        { label: "동치", value: values.chord },
-        { label: "트릴", value: values.trill },
-        { label: "글리산도", value: values.glissando },
         { label: "연타", value: values.repetition },
+        { label: "폴리리듬", value: values.chord },
+        { label: "즈레", value: values.trill },
+        { label: "글리산도", value: values.glissando },
     ];
 
     return (

--- a/components/music/scoreTrend.tsx
+++ b/components/music/scoreTrend.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatScoreRecordDate } from "@/lib/music/scoreTrend";
 import {
     Line,
     LineChart,
@@ -10,7 +11,7 @@ import {
 } from "recharts";
 
 interface ScoreTrendProps {
-    plays: {
+    points: {
         id: number;
         score: number;
         rank: string;
@@ -18,16 +19,16 @@ interface ScoreTrendProps {
     }[];
 }
 
-export default function ScoreTrend({ plays }: ScoreTrendProps) {
-    if (plays.length === 0) {
+export default function ScoreTrend({ points }: ScoreTrendProps) {
+    if (points.length === 0) {
         return (
             <div className="text-text-disabled flex h-32 items-center justify-center text-sm">
-                최근 플레이 기록이 없습니다.
+                베스트 스코어 갱신 이력이 없습니다.
             </div>
         );
     }
 
-    const scores = plays.map((play) => play.score);
+    const scores = points.map((point) => point.score);
     const minimum = Math.max(0, Math.min(...scores) - 10000);
     const maximum = Math.min(1000000, Math.max(...scores) + 10000);
 
@@ -35,7 +36,7 @@ export default function ScoreTrend({ plays }: ScoreTrendProps) {
         <div className="h-40 w-full">
             <ResponsiveContainer width="100%" height="100%">
                 <LineChart
-                    data={plays}
+                    data={points}
                     margin={{ top: 12, right: 10, bottom: 0, left: 10 }}
                 >
                     <XAxis dataKey="play_time" hide />
@@ -53,7 +54,9 @@ export default function ScoreTrend({ plays }: ScoreTrendProps) {
                             "점수",
                         ]}
                         labelFormatter={(_, payload) =>
-                            payload[0]?.payload.play_time ?? ""
+                            formatScoreRecordDate(
+                                payload[0]?.payload.play_time ?? ""
+                            )
                         }
                     />
                     <Line
@@ -72,8 +75,10 @@ export default function ScoreTrend({ plays }: ScoreTrendProps) {
                 </LineChart>
             </ResponsiveContainer>
             <div className="text-text-disabled -mt-5 flex justify-between text-[10px]">
-                <span>{plays[0]?.play_time.split(" ")[0]}</span>
-                <span>{plays.at(-1)?.play_time.split(" ")[0]} 현재</span>
+                <span>{formatScoreRecordDate(points[0]?.play_time ?? "")}</span>
+                <span>
+                    {formatScoreRecordDate(points.at(-1)?.play_time ?? "")}
+                </span>
             </div>
         </div>
     );

--- a/components/music/search/musicSearchBar.tsx
+++ b/components/music/search/musicSearchBar.tsx
@@ -30,7 +30,7 @@ export default function MusicSearchBar({
                 type="button"
                 onClick={onToggleFilter}
                 aria-expanded={filterOpen}
-                className="bg-surface-muted text-section rounded-card flex h-9.5 min-w-14 shrink-0 items-center justify-center px-3 whitespace-nowrap"
+                className="bg-surface-muted text-section hover:bg-border focus-visible:ring-text-secondary/30 rounded-card flex h-9.5 min-w-14 shrink-0 cursor-pointer items-center justify-center px-3 whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:outline-none"
             >
                 필터
             </button>

--- a/components/music/search/musicSearchBar.tsx
+++ b/components/music/search/musicSearchBar.tsx
@@ -1,4 +1,5 @@
 import type { UseFormRegisterReturn } from "react-hook-form";
+import { Search } from "lucide-react";
 
 interface MusicSearchBarProps {
     registration: UseFormRegisterReturn;
@@ -13,9 +14,12 @@ export default function MusicSearchBar({
     onToggleFilter,
 }: MusicSearchBarProps) {
     return (
-        <div className="flex gap-2">
-            <div className="border-border bg-surface rounded-card flex h-9.5 flex-1 items-center gap-2 border px-3">
-                <span className="border-text-disabled size-4 rounded-full border-2" />
+        <div className="flex min-w-0 gap-2">
+            <div className="border-border bg-surface rounded-card focus-within:border-text-secondary focus-within:ring-text-secondary/20 flex h-9.5 min-w-0 flex-1 items-center gap-2 border px-3 transition focus-within:ring-2">
+                <Search
+                    className="text-text-disabled size-4 shrink-0"
+                    aria-hidden="true"
+                />
                 <input
                     placeholder="곡 제목 · 아티스트 검색"
                     className="text-input placeholder:text-text-disabled h-full min-w-0 flex-1 bg-transparent outline-none"
@@ -26,7 +30,7 @@ export default function MusicSearchBar({
                 type="button"
                 onClick={onToggleFilter}
                 aria-expanded={filterOpen}
-                className="bg-surface-muted text-section rounded-card flex h-9.5 items-center px-3"
+                className="bg-surface-muted text-section rounded-card flex h-9.5 min-w-14 shrink-0 items-center justify-center px-3 whitespace-nowrap"
             >
                 필터
             </button>

--- a/components/profile/dashboard/profileBestPlays.tsx
+++ b/components/profile/dashboard/profileBestPlays.tsx
@@ -36,7 +36,7 @@ export default function ProfileBestPlays({
                                 ? "베스트 성과 접기"
                                 : "베스트 성과 전체 보기"
                         }
-                        className="text-caption flex items-center gap-1"
+                        className="text-caption hover:bg-surface-muted hover:text-text-primary focus-visible:ring-text-secondary/30 flex cursor-pointer items-center gap-1 rounded px-1.5 py-1 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                     >
                         {expanded ? "접기" : "전체"}
                         <ChevronRight

--- a/components/profile/dashboard/profileGradeTrend.tsx
+++ b/components/profile/dashboard/profileGradeTrend.tsx
@@ -11,9 +11,8 @@ export default function ProfileGradeTrend({
 }) {
     return (
         <section className="bg-surface rounded-card p-4">
-            <div className="mb-2 flex items-center justify-between">
+            <div className="mb-2">
                 <h2 className="text-section font-bold">그레이드 추이</h2>
-                <span className="text-caption">최근 {data.length}회</span>
             </div>
             <ProfileGradeChart data={data} mode={mode} />
             {data.length > 1 ? (

--- a/components/profile/dashboard/profileHeader.tsx
+++ b/components/profile/dashboard/profileHeader.tsx
@@ -77,7 +77,7 @@ export default function ProfileHeader({ user, isOwner }: ProfileHeaderProps) {
                     <button
                         type="button"
                         onClick={() => void handleShare()}
-                        className="border-border text-text-secondary hover:text-text-primary flex size-9 items-center justify-center rounded-md border"
+                        className="border-border text-text-secondary hover:bg-surface-muted hover:text-text-primary focus-visible:ring-text-secondary/30 flex size-9 cursor-pointer items-center justify-center rounded-md border transition-colors focus-visible:ring-2 focus-visible:outline-none"
                         aria-label="프로필 공유"
                     >
                         <Share2 size={16} />
@@ -85,7 +85,7 @@ export default function ProfileHeader({ user, isOwner }: ProfileHeaderProps) {
                     {isOwner ? (
                         <Link
                             href="/profile/settings"
-                            className="border-border text-text-secondary hover:text-text-primary flex size-9 items-center justify-center rounded-md border"
+                            className="border-border text-text-secondary hover:bg-surface-muted hover:text-text-primary focus-visible:ring-text-secondary/30 flex size-9 cursor-pointer items-center justify-center rounded-md border transition-colors focus-visible:ring-2 focus-visible:outline-none"
                             aria-label="프로필 설정"
                         >
                             <Settings size={16} />

--- a/components/profile/dashboard/profileModeTabs.tsx
+++ b/components/profile/dashboard/profileModeTabs.tsx
@@ -23,10 +23,10 @@ export default function ProfileModeTabs({
                     type="button"
                     onClick={() => onChange(item)}
                     className={cn(
-                        "h-9 rounded-md text-sm font-semibold transition-colors",
+                        "focus-visible:ring-text-secondary/30 h-9 cursor-pointer rounded-md text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none",
                         mode === item
-                            ? "bg-text-primary text-bg"
-                            : "text-text-secondary"
+                            ? "bg-text-primary text-bg hover:bg-text-primary/90"
+                            : "text-text-secondary hover:bg-surface-muted hover:text-text-primary"
                     )}
                 >
                     {item === "basic" ? "Basic" : "Recital"}

--- a/components/profile/dashboard/profileRankDistribution.tsx
+++ b/components/profile/dashboard/profileRankDistribution.tsx
@@ -32,7 +32,7 @@ export default function ProfileRankDistribution({
                 <button
                     type="button"
                     onClick={onToggle}
-                    className="text-caption flex items-center gap-1"
+                    className="text-caption hover:bg-surface-muted hover:text-text-primary focus-visible:ring-text-secondary/30 flex cursor-pointer items-center gap-1 rounded px-1.5 py-1 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
                     {expanded ? "접기" : "전체"}
                     <ChevronDown

--- a/components/profile/dashboard/profileRecentPlays.tsx
+++ b/components/profile/dashboard/profileRecentPlays.tsx
@@ -34,7 +34,7 @@ export default function ProfileRecentPlays({
                                 ? "최근 플레이 접기"
                                 : "최근 플레이 전체 보기"
                         }
-                        className="text-caption flex items-center gap-1"
+                        className="text-caption hover:bg-surface-muted hover:text-text-primary focus-visible:ring-text-secondary/30 flex cursor-pointer items-center gap-1 rounded px-1.5 py-1 transition-colors focus-visible:ring-2 focus-visible:outline-none"
                     >
                         {expanded ? "접기" : "전체"}
                         <ChevronRight

--- a/components/profile/profile.tsx
+++ b/components/profile/profile.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { LogOut } from "lucide-react";
 import { useState } from "react";
 
 import { logout } from "@/app/(nevigation)/profile/[id]/actions";
@@ -80,9 +79,8 @@ export default function ProfileDashboard({
                 <form action={logout}>
                     <button
                         type="submit"
-                        className="border-danger/50 text-danger rounded-card flex h-11 w-full items-center justify-center gap-2 border text-sm font-semibold"
+                        className="border-danger/50 text-danger hover:bg-danger/10 focus-visible:ring-danger/30 rounded-card flex h-11 w-full cursor-pointer items-center justify-center border text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
                     >
-                        <LogOut size={16} />
                         로그아웃
                     </button>
                 </form>

--- a/components/profile/profileSettingCard.tsx
+++ b/components/profile/profileSettingCard.tsx
@@ -145,7 +145,7 @@ export default function ProfileSettingCard({ user }: ProfileSettingCardProps) {
                     <p className="text-caption mt-1">
                         JPG, PNG, WebP · 최대 4MB
                     </p>
-                    <label className="border-border text-text-primary rounded-card mt-3 inline-flex h-9 cursor-pointer items-center gap-2 border px-3 text-xs font-semibold">
+                    <label className="border-border text-text-primary hover:bg-surface-muted focus-within:ring-text-secondary/30 rounded-card mt-3 inline-flex h-9 cursor-pointer items-center gap-2 border px-3 text-xs font-semibold transition-colors focus-within:ring-2">
                         <Camera className="size-4" aria-hidden />
                         사진 변경
                         <input
@@ -204,7 +204,7 @@ export default function ProfileSettingCard({ user }: ProfileSettingCardProps) {
                     </div>
                     <a
                         href="/discord/start?returnTo=/profile/settings"
-                        className="border-border text-text-primary rounded-card flex h-9 shrink-0 items-center border px-3 text-xs font-bold"
+                        className="border-border text-text-primary hover:bg-surface-muted focus-visible:ring-text-secondary/30 rounded-card flex h-9 shrink-0 cursor-pointer items-center border px-3 text-xs font-bold transition-colors focus-visible:ring-2 focus-visible:outline-none"
                     >
                         {user.discord_id ? "다시 연결" : "연결"}
                     </a>
@@ -220,14 +220,14 @@ export default function ProfileSettingCard({ user }: ProfileSettingCardProps) {
             <div className="grid grid-cols-2 gap-2">
                 <Link
                     href={`/profile/${user.id}`}
-                    className="border-border text-text-secondary rounded-card flex h-11 items-center justify-center border text-sm font-semibold"
+                    className="border-border text-text-secondary hover:bg-surface-muted hover:text-text-primary focus-visible:ring-text-secondary/30 rounded-card flex h-11 cursor-pointer items-center justify-center border text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
                     취소
                 </Link>
                 <button
                     type="submit"
                     disabled={isSubmitting}
-                    className="bg-text-primary text-bg rounded-card flex h-11 cursor-pointer items-center justify-center gap-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
+                    className="bg-text-primary text-bg hover:bg-text-primary/90 focus-visible:ring-text-secondary/30 rounded-card flex h-11 cursor-pointer items-center justify-center gap-2 text-sm font-bold transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
                 >
                     <Save className="size-4" aria-hidden />
                     {isSubmitting ? "저장 중" : "저장"}

--- a/e2e/content-interactions.spec.ts
+++ b/e2e/content-interactions.spec.ts
@@ -27,6 +27,10 @@ test("검정 선택 항목을 아코디언으로 열고 닫는다", async ({ pag
     await page.goto("/exams");
     await expectPageLoaded(page);
 
+    await expect(
+        page.getByRole("button", { name: "Basic", exact: true })
+    ).toHaveClass(/bg-text-primary/);
+
     const selector = page.locator("main button[aria-expanded]").first();
     const stageTable = page.getByText("과제곡", { exact: true });
 

--- a/e2e/music.spec.ts
+++ b/e2e/music.spec.ts
@@ -5,6 +5,10 @@ import { expectNoHorizontalOverflow, expectPageLoaded } from "./helpers";
 test("악곡 목록의 정렬과 보기 방식을 URL에 반영한다", async ({ page }) => {
     await page.goto("/music");
     await expectPageLoaded(page);
+    await expect(page.getByRole("button", { name: "필터" })).toHaveCSS(
+        "white-space",
+        "nowrap"
+    );
 
     const listView = page.getByRole("button", { name: "리스트 보기" });
     const gridView = page.getByRole("button", { name: "그리드 보기" });

--- a/e2e/public-navigation.spec.ts
+++ b/e2e/public-navigation.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from "@playwright/test";
 import { expectNoHorizontalOverflow, expectPageLoaded } from "./helpers";
 
 const publicRoutes = [
-    { label: "악곡", path: "/music", heading: "악곡" },
+    { label: "악곡", path: "/music", heading: "악곡 검색" },
     { label: "랭킹", path: "/rankings", heading: "유저 랭킹" },
     { label: "서열", path: "/tiers", heading: "서열표" },
     { label: "빙고", path: "/bingo", heading: "빙고" },

--- a/e2e/public-navigation.spec.ts
+++ b/e2e/public-navigation.spec.ts
@@ -47,6 +47,28 @@ test("로그인 페이지에서 Discord 로그인과 비회원 이동을 제공�
     await expectNoHorizontalOverflow(page);
 });
 
+test("홈 유저 랭킹의 Basic과 Recital을 전환한다", async ({ page }) => {
+    await page.goto("/");
+
+    const recitalLink = page.getByRole("link", {
+        name: "Recital",
+        exact: true,
+    });
+    await recitalLink.click();
+
+    await expect(page).toHaveURL(/\?ranking=recital$/);
+    await expect(recitalLink).toHaveAttribute("aria-current", "page");
+
+    const basicLink = page.getByRole("link", {
+        name: "Basic",
+        exact: true,
+    });
+    await basicLink.click();
+
+    await expect(page).toHaveURL(/\?ranking=basic$/);
+    await expect(basicLink).toHaveAttribute("aria-current", "page");
+});
+
 test("핵심 공개 화면은 390px에서 가로로 넘치지 않는다", async ({ page }) => {
     for (const path of [
         "/",

--- a/lib/music/scoreTrend.ts
+++ b/lib/music/scoreTrend.ts
@@ -1,0 +1,24 @@
+interface ScoreRecord {
+    score: number;
+}
+
+// 시간순 기록에서 이전 최고점을 넘어선 베스트 갱신만 남김
+export function selectScoreImprovements<T extends ScoreRecord>(records: T[]) {
+    let bestScore = 0;
+
+    return records.filter((record) => {
+        if (record.score <= bestScore) return false;
+
+        bestScore = record.score;
+        return true;
+    });
+}
+
+// ISO와 기존 플레이 날짜 문자열을 화면용 날짜로 통일함
+export function formatScoreRecordDate(value: string) {
+    return value
+        .split("T")[0]
+        .split(" ")[0]
+        .replaceAll("-", ".")
+        .replaceAll("/", ".");
+}

--- a/lib/musicCategories.ts
+++ b/lib/musicCategories.ts
@@ -9,6 +9,15 @@ export const MUSIC_CATEGORY_VALUES = [
 
 export type MusicCategory = (typeof MUSIC_CATEGORY_VALUES)[number];
 
+export const MUSIC_CATEGORY_BADGE_STYLES: Record<MusicCategory, string> = {
+    pops: "bg-genre-pops/15 text-genre-pops",
+    anime: "bg-genre-anime/15 text-genre-anime",
+    BM: "bg-genre-bm/15 text-genre-bm",
+    Org: "bg-genre-original/15 text-genre-original",
+    Var: "bg-genre-variety/15 text-genre-variety",
+    "Cl/Jz": "bg-genre-classic-jazz/15 text-genre-classic-jazz",
+};
+
 // DB와 URL의 카테고리 표기를 공식 필터 값으로 통일함
 export function normalizeMusicCategory(value: string) {
     const normalizedValue = value.trim().toLocaleLowerCase("en-US");

--- a/prisma/migrations/20260718150000_cascade_exam_achievement_submission/migration.sql
+++ b/prisma/migrations/20260718150000_cascade_exam_achievement_submission/migration.sql
@@ -1,0 +1,15 @@
+-- 삭제된 승인 제출이 남긴 고아 합격 이력을 정리함
+DELETE FROM "ExamAchievement"
+WHERE "submission_id" IS NULL;
+
+-- 합격 이력은 승인 제출과 항상 함께 존재하도록 관계를 강화함
+ALTER TABLE "ExamAchievement"
+DROP CONSTRAINT "ExamAchievement_submission_id_fkey";
+
+ALTER TABLE "ExamAchievement"
+ALTER COLUMN "submission_id" SET NOT NULL;
+
+ALTER TABLE "ExamAchievement"
+ADD CONSTRAINT "ExamAchievement_submission_id_fkey"
+FOREIGN KEY ("submission_id") REFERENCES "ExamSubmission"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -500,8 +500,8 @@ model ExamAchievement {
   user         User            @relation(fields: [userId], references: [id], onDelete: Cascade)
   examId       Int             @map("exam_id")
   exam         Exam            @relation(fields: [examId], references: [id], onDelete: Cascade)
-  submissionId Int?            @unique @map("submission_id")
-  submission   ExamSubmission? @relation(fields: [submissionId], references: [id], onDelete: SetNull)
+  submissionId Int            @unique @map("submission_id")
+  submission   ExamSubmission @relation(fields: [submissionId], references: [id], onDelete: Cascade)
 
   @@unique([userId, examId])
   @@index([examId, achievedAt])

--- a/tests/admin-actions.test.ts
+++ b/tests/admin-actions.test.ts
@@ -29,7 +29,10 @@ const mocks = vi.hoisted(() => ({
 const transactionClient = {
     musicChart: { update: mocks.musicChartUpdate },
     chartLevelConstantHistory: { create: mocks.constantHistoryCreate },
-    examSubmission: { update: mocks.examSubmissionUpdate },
+    examSubmission: {
+        update: mocks.examSubmissionUpdate,
+        delete: mocks.examSubmissionDelete,
+    },
     examAchievement: {
         upsert: mocks.examAchievementUpsert,
         deleteMany: mocks.examAchievementDeleteMany,
@@ -292,7 +295,7 @@ describe("관리자 액션", () => {
         );
     });
 
-    it("검정 제출 기록을 삭제한 뒤 연결된 Blob을 정리한다", async () => {
+    it("검정 제출과 연결된 합격 이력을 함께 삭제한 뒤 Blob을 정리한다", async () => {
         mocks.examSubmissionFindUnique.mockResolvedValue({
             id: 50,
             proofImageUrl:
@@ -303,6 +306,9 @@ describe("관리자 액션", () => {
 
         await deleteExamSubmission(formData);
 
+        expect(mocks.examAchievementDeleteMany).toHaveBeenCalledWith({
+            where: { submissionId: 50 },
+        });
         expect(mocks.examSubmissionDelete).toHaveBeenCalledWith({
             where: { id: 50 },
         });

--- a/tests/evaluation-schema.test.ts
+++ b/tests/evaluation-schema.test.ts
@@ -4,6 +4,7 @@ import {
     chartEvaluationReactionSchema,
     chartEvaluationSchema,
 } from "@/app/(nevigation)/music/[index]/[difficulty]/evaluationSchema";
+import { patternItems } from "@/components/music/musicTierVoteConfig";
 
 const validEvaluation = {
     chartId: 1,
@@ -17,6 +18,16 @@ const validEvaluation = {
 };
 
 describe("chartEvaluationSchema", () => {
+    it("패턴 항목을 서비스 기준 순서로 제공한다", () => {
+        expect(patternItems.map((item) => item.label)).toEqual([
+            "계단",
+            "연타",
+            "폴리리듬",
+            "즈레",
+            "글리산도",
+        ]);
+    });
+
     it("올바른 체감 난이도와 다섯 패턴 값을 허용한다", () => {
         expect(chartEvaluationSchema.safeParse(validEvaluation).success).toBe(
             true

--- a/tests/score-trend.test.ts
+++ b/tests/score-trend.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    formatScoreRecordDate,
+    selectScoreImprovements,
+} from "@/lib/music/scoreTrend";
+
+describe("베스트 스코어 추이", () => {
+    it("시간순 기록에서 최고점이 상승한 기록을 모두 남긴다", () => {
+        const records = [
+            { id: 1, score: 900000 },
+            { id: 2, score: 920000 },
+            { id: 3, score: 910000 },
+            { id: 4, score: 920000 },
+            { id: 5, score: 950000 },
+        ];
+
+        expect(selectScoreImprovements(records)).toEqual([
+            { id: 1, score: 900000 },
+            { id: 2, score: 920000 },
+            { id: 5, score: 950000 },
+        ]);
+    });
+
+    it("점수가 없는 기록은 추이에 포함하지 않는다", () => {
+        expect(
+            selectScoreImprovements([
+                { id: 1, score: 0 },
+                { id: 2, score: 0 },
+            ])
+        ).toEqual([]);
+    });
+
+    it("ISO와 기존 플레이 날짜를 동일한 형식으로 표시한다", () => {
+        expect(formatScoreRecordDate("2025-10-01T17:58:33.236Z")).toBe(
+            "2025.10.01"
+        );
+        expect(formatScoreRecordDate("2025/05/29 12:30:00")).toBe("2025.05.29");
+    });
+});


### PR DESCRIPTION
## 주요 변경 사항

- 모바일 악곡 검색 레이아웃과 포커스 스타일 개선
- 홈 프로필 카드, 유저 랭킹 및 메뉴 상호작용 개선
- NOSTALGIA 공식 X 소식 영역 추가
- 악곡 상세 스코어 추이와 기록 표시 개선
- 악곡 카테고리 색상 및 패턴 투표 항목 정리
- 프로필, 랭킹, 서열표, 빙고, 검정 페이지의 hover 및 클릭 피드백 보강
- 검정 합격 인증 UI와 과제곡 표시 개선
- 검정 제출 삭제 시 합격 기록도 함께 정리되도록 데이터 관계 수정
- 관련 단위 테스트와 E2E 테스트 보강

## 데이터베이스

- 검정 제출과 합격 기록 관계를 `CASCADE`로 변경
- dev 및 main DB에 공식 레벨 상수 적용
- REAL 세부 상수와 Normal, Hard, Expert 공식 상수 검증 완료

## 검증

- [x] TypeScript
- [x] 관련 단위 테스트
- [ ] GitHub Actions CI
- [ ] Preview 모바일 환경 확인
- [ ] 병합 후 Production 동작 확인